### PR TITLE
Initial commit for smart-queue with test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ jspm_packages
 
 # yarn.lock exists so don't commit package-lock.json
 package-lock.json
+
+#vscode
+.vscode

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "queue",
+  "version": "1.0.0",
+  "description": "queue plugins",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "jest": {
+    "rootDir": "smart-queue"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/redux-offline/queue/.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/redux-offline/queue/issues"
+  },
+  "homepage": "https://github.com/redux-offline/queue#readme",
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
+    "babel-eslint": "^7.2.3",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-flow-strip-types": "^6.18.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-latest": "^6.24.1",
+    "babel-preset-stage-3": "^6.24.1",
+    "eslint": "^4.6.1",
+    "jest": "^19.0.2",
+    "prettier": "^1.6.1"
+  },
+  "dependencies": {
+    "babel-preset-env": "^1.6.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/redux-offline/queue#readme",
   "devDependencies": {
+    "babel-preset-env": "^1.6.1",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^7.2.3",
@@ -31,8 +32,5 @@
     "eslint": "^4.6.1",
     "jest": "^19.0.2",
     "prettier": "^1.6.1"
-  },
-  "dependencies": {
-    "babel-preset-env": "^1.6.1"
   }
 }

--- a/smart-queue/__test__/test.js
+++ b/smart-queue/__test__/test.js
@@ -1,92 +1,128 @@
-import Q from '../index';
-import * as QueueActionTypes from '../action-types';
+import Q from "../index";
+import * as QueueActionTypes from "../action-types";
 
 let queue = [];
-let createQueueAction = {type: 'CREATE', meta: {offline: {queue: {method: QueueActionTypes.CREATE, key: '1'}}}};
-let createQueueAction2 = {type: 'CREATE2', meta: {offline: {queue: {method: QueueActionTypes.CREATE, key: '2'}}}};
-let createQueueAction3 = {type: 'CREATE3', meta: {offline: {queue: {method: QueueActionTypes.CREATE, key: '3'}}}};
-let updateQueueAction = {type: 'UPDATE', meta: {offline: {queue: {method: QueueActionTypes.UPDATE, key: '1'}}}};
-let updateQueueAction2 = {type: 'UPDATE2', meta: {offline: {queue: {method: QueueActionTypes.UPDATE, key: '2'}}}};
-let updateNonExistingQueueAction = {type: 'Non-Existing', meta: {offline: {queue: {method: QueueActionTypes.UPDATE, key: '-1'}}}};
-let deleteQueueAction = {type: 'DELETE', meta: {offline: {queue: {method: QueueActionTypes.DELETE, key: '1'}}}};
-let deleteQueueAction2 = {type: 'DELETE2', meta: {offline: {queue: {method: QueueActionTypes.DELETE, key: '2'}}}};
-let deleteNonExistingQueueAction = {type: 'NON-Existing', meta: {offline: {queue: {method: QueueActionTypes.DELETE, key: '-1'}}}};
-let readQueueAction = {type: 'READ', meta: {offline: {queue: {method: QueueActionTypes.READ, key: '1'}}}};
-let readQueueAction2 = {type: 'READ2', meta: {offline: {queue: {method: QueueActionTypes.READ, key: '2'}}}};
-let missingActionMethod = {type: 'MISSING-METHOD', meta: {offline: {queue: {method: null, key: '2'}}}};
-let missingActionKey = {type: 'MISSING-KEY', meta: {offline: {queue: {method: QueueActionTypes.CREATE, key: null}}}};
+let createQueueAction = {
+  type: "CREATE",
+  meta: { offline: { queue: { method: QueueActionTypes.CREATE, key: "1" } } }
+};
+let createQueueAction2 = {
+  type: "CREATE2",
+  meta: { offline: { queue: { method: QueueActionTypes.CREATE, key: "2" } } }
+};
+let createQueueAction3 = {
+  type: "CREATE3",
+  meta: { offline: { queue: { method: QueueActionTypes.CREATE, key: "3" } } }
+};
+let updateQueueAction = {
+  type: "UPDATE",
+  meta: { offline: { queue: { method: QueueActionTypes.UPDATE, key: "1" } } }
+};
+let updateQueueAction2 = {
+  type: "UPDATE2",
+  meta: { offline: { queue: { method: QueueActionTypes.UPDATE, key: "2" } } }
+};
+let updateNonExistingQueueAction = {
+  type: "Non-Existing",
+  meta: { offline: { queue: { method: QueueActionTypes.UPDATE, key: "-1" } } }
+};
+let deleteQueueAction = {
+  type: "DELETE",
+  meta: { offline: { queue: { method: QueueActionTypes.DELETE, key: "1" } } }
+};
+let deleteQueueAction2 = {
+  type: "DELETE2",
+  meta: { offline: { queue: { method: QueueActionTypes.DELETE, key: "2" } } }
+};
+let deleteNonExistingQueueAction = {
+  type: "NON-Existing",
+  meta: { offline: { queue: { method: QueueActionTypes.DELETE, key: "-1" } } }
+};
+let readQueueAction = {
+  type: "READ",
+  meta: { offline: { queue: { method: QueueActionTypes.READ, key: "1" } } }
+};
+let readQueueAction2 = {
+  type: "READ2",
+  meta: { offline: { queue: { method: QueueActionTypes.READ, key: "2" } } }
+};
+let missingActionMethod = {
+  type: "MISSING-METHOD",
+  meta: { offline: { queue: { method: null, key: "2" } } }
+};
+let missingActionKey = {
+  type: "MISSING-KEY",
+  meta: { offline: { queue: { method: QueueActionTypes.CREATE, key: null } } }
+};
+let valinaAction = { type: "VANILA_ACTION", meta: { offline: {} } };
 
 beforeEach(() => {
   queue = [];
 });
 // create single item
-test('Single insertion test', () => {
+test("Single insertion test", () => {
   queue = Q.enqueue(queue, createQueueAction);
   expect(queue.length).toBe(1);
 });
 
 // create then update same item
-test(
-  'Create then update same item', () => {
-    queue = Q.enqueue(queue, createQueueAction);
-    queue = Q.enqueue(queue, updateQueueAction);
-    expect(queue.length).toBe(1);
-    expect(Q.peek(queue).type).toBe('UPDATE');
-  }
-);
-
-test(
-  'Create then update then delete same item', () => {
-    queue = Q.enqueue(queue, createQueueAction);
-    queue = Q.enqueue(queue, updateQueueAction);
-    queue = Q.enqueue(queue, deleteQueueAction);
-    expect(queue.length).toBe(0);
-  }
-);
-
-test('Insert then read', () => {
-  queue = Q.enqueue(queue, createQueueAction);
-  expect(Q.peek(queue).meta.offline.queue.key).toBe('1');
-});
-
-test('Insert -> update then read', () => {
+test("Create then update same item", () => {
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, updateQueueAction);
-  expect(Q.peek(queue).meta.offline.queue.key).toBe('1');
-  expect(Q.peek(queue).type).toBe('UPDATE');
+  expect(queue.length).toBe(1);
+  expect(Q.peek(queue).type).toBe("UPDATE");
 });
 
-test('Multiple create with same key', () => {
+test("Create then update then delete same item", () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, updateQueueAction);
+  queue = Q.enqueue(queue, deleteQueueAction);
+  expect(queue.length).toBe(0);
+});
+
+test("Insert then read", () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  expect(Q.peek(queue).meta.offline.queue.key).toBe("1");
+});
+
+test("Insert -> update then read", () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, updateQueueAction);
+  expect(Q.peek(queue).meta.offline.queue.key).toBe("1");
+  expect(Q.peek(queue).type).toBe("UPDATE");
+});
+
+test("Multiple create with same key", () => {
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction);
   expect(queue.length).toBe(1);
 });
 
-test('Multiple create with different keys', () => {
+test("Multiple create with different keys", () => {
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction2);
   queue = Q.enqueue(queue, createQueueAction3);
   expect(queue.length).toBe(3);
-  expect(Q.peek(queue).type).toBe('CREATE');
+  expect(Q.peek(queue).type).toBe("CREATE");
   queue = Q.dequeue(queue);
-  expect(Q.peek(queue).type).toBe('CREATE2');
+  expect(Q.peek(queue).type).toBe("CREATE2");
   queue = Q.dequeue(queue);
-  expect(Q.peek(queue).type).toBe('CREATE3');
+  expect(Q.peek(queue).type).toBe("CREATE3");
 });
 
-test('Multiple create with same key followed by delete', () => {
+test("Multiple create with same key followed by delete", () => {
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction);
   const item = Q.peek(queue);
-  expect(item.type).toBe('CREATE');
+  expect(item.type).toBe("CREATE");
   expect(queue.length).toBe(1);
   queue = Q.enqueue(queue, deleteQueueAction);
   expect(queue.length).toBe(0);
 });
 
-test('Multiple create with different key followed by delete', () => {
+test("Multiple create with different key followed by delete", () => {
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction2);
   queue = Q.enqueue(queue, createQueueAction3);
@@ -94,7 +130,7 @@ test('Multiple create with different key followed by delete', () => {
   expect(queue.length).toBe(2);
 });
 
-test('Multiple create with different key followed by delete and 2 peek', () => {
+test("Multiple create with different key followed by delete and 2 peek", () => {
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction2);
   queue = Q.enqueue(queue, createQueueAction3);
@@ -102,65 +138,65 @@ test('Multiple create with different key followed by delete and 2 peek', () => {
   const firstItem = Q.peek(queue);
   queue = Q.dequeue(queue);
   const thirdItem = Q.peek(queue);
-  expect(firstItem.type).toBe('CREATE');
-  expect(thirdItem.type).toBe('CREATE3');
+  expect(firstItem.type).toBe("CREATE");
+  expect(thirdItem.type).toBe("CREATE3");
 });
 
-test('2 creates followed by update of first item', () => {
+test("2 creates followed by update of first item", () => {
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction2);
   queue = Q.enqueue(queue, updateQueueAction);
   const firstItem = Q.peek(queue);
   queue = Q.dequeue(queue);
   const thirdItem = Q.peek(queue);
-  expect(firstItem.type).toBe('UPDATE');
-  expect(thirdItem.type).toBe('CREATE2');
+  expect(firstItem.type).toBe("UPDATE");
+  expect(thirdItem.type).toBe("CREATE2");
 });
 
-test('2 creates followed by update of second item', () => {
+test("2 creates followed by update of second item", () => {
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction2);
   queue = Q.enqueue(queue, updateQueueAction2);
   const firstItem = Q.peek(queue);
   queue = Q.dequeue(queue);
   const thirdItem = Q.peek(queue);
-  expect(firstItem.type).toBe('CREATE');
-  expect(thirdItem.type).toBe('UPDATE2');
+  expect(firstItem.type).toBe("CREATE");
+  expect(thirdItem.type).toBe("UPDATE2");
 });
 
-test('2 reads', () => {
+test("2 reads", () => {
   queue = Q.enqueue(queue, readQueueAction);
   queue = Q.enqueue(queue, readQueueAction2);
   const firstItem = Q.peek(queue);
   queue = Q.dequeue(queue);
   const thirdItem = Q.peek(queue);
-  expect(firstItem.type).toBe('READ');
-  expect(thirdItem.type).toBe('READ2');
+  expect(firstItem.type).toBe("READ");
+  expect(thirdItem.type).toBe("READ2");
 });
 
-test('Delete non-existing queue actions', () => {
+test("Delete non-existing queue actions", () => {
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction2);
   queue = Q.enqueue(queue, deleteNonExistingQueueAction);
   const firstItem = Q.peek(queue);
   queue = Q.dequeue(queue);
   const thirdItem = Q.peek(queue);
-  expect(firstItem.type).toBe('CREATE');
-  expect(thirdItem.type).toBe('CREATE2');
+  expect(firstItem.type).toBe("CREATE");
+  expect(thirdItem.type).toBe("CREATE2");
 });
 
-test('Update non-existing queue actions', () => {
+test("Update non-existing queue actions", () => {
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction2);
   queue = Q.enqueue(queue, updateNonExistingQueueAction);
   const firstItem = Q.peek(queue);
   queue = Q.dequeue(queue);
   const thirdItem = Q.peek(queue);
-  expect(firstItem.type).toBe('CREATE');
-  expect(thirdItem.type).toBe('CREATE2');
+  expect(firstItem.type).toBe("CREATE");
+  expect(thirdItem.type).toBe("CREATE2");
 });
 
-test('Missing action method', () => {
+test("Missing action method", () => {
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction2);
   queue = Q.enqueue(queue, missingActionMethod);
@@ -168,11 +204,11 @@ test('Missing action method', () => {
   const firstItem = Q.peek(queue);
   queue = Q.dequeue(queue);
   const thirdItem = Q.peek(queue);
-  expect(firstItem.type).toBe('CREATE');
-  expect(thirdItem.type).toBe('CREATE2');
+  expect(firstItem.type).toBe("CREATE");
+  expect(thirdItem.type).toBe("CREATE2");
 });
 
-test('Missing action key', () => {
+test("Missing action key", () => {
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction2);
   queue = Q.enqueue(queue, missingActionKey);
@@ -180,6 +216,45 @@ test('Missing action key', () => {
   const firstItem = Q.peek(queue);
   queue = Q.dequeue(queue);
   const thirdItem = Q.peek(queue);
-  expect(firstItem.type).toBe('CREATE');
-  expect(thirdItem.type).toBe('CREATE2');
+  expect(firstItem.type).toBe("CREATE");
+  expect(thirdItem.type).toBe("CREATE2");
+});
+
+test("add valina action to queue", () => {
+  queue = Q.enqueue(queue, valinaAction);
+  queue = Q.enqueue(queue, valinaAction);
+  expect(queue.length).toBe(2);
+});
+
+test("Valina action with Smart-queue action to queue", () => {
+  queue = Q.enqueue(queue, valinaAction);
+  queue = Q.enqueue(queue, valinaAction);
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction2);
+  expect(queue.length).toBe(4);
+});
+
+test("Valina action with duplicate Smart-queue action to queue", () => {
+  queue = Q.enqueue(queue, valinaAction);
+  queue = Q.enqueue(queue, valinaAction);
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction);
+  expect(queue.length).toBe(3);
+});
+
+test("Valina action and duplicate Smart-queue action reading from queue", () => {
+  queue = Q.enqueue(queue, valinaAction);
+  queue = Q.enqueue(queue, valinaAction);
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction);
+  expect(queue.length).toBe(3);
+  let item = Q.peek(queue);
+  queue = Q.dequeue(queue);
+  expect(item.type).toBe("VANILA_ACTION");
+  item = Q.peek(queue);
+  queue = Q.dequeue(queue);
+  expect(item.type).toBe("VANILA_ACTION");
+  item = Q.peek(queue);
+  queue = Q.dequeue(queue);
+  expect(item.type).toBe("CREATE");
 });

--- a/smart-queue/__test__/test.js
+++ b/smart-queue/__test__/test.js
@@ -1,0 +1,98 @@
+import Q from '../index';
+import * as QueueActionTypes from '../action-types';
+
+let queue = [];
+let createQueueAction = {type: 'CREATE', meta: {offline: {queue: {method: QueueActionTypes.CREATE, key: '1'}}}};
+let createQueueAction2 = {type: 'CREATE2', meta: {offline: {queue: {method: QueueActionTypes.CREATE, key: '2'}}}};
+let createQueueAction3 = {type: 'CREATE3', meta: {offline: {queue: {method: QueueActionTypes.CREATE, key: '3'}}}};
+let updateQueueAction = {type: 'UPDATE', meta: {offline: {queue: {method: QueueActionTypes.UPDATE, key: '1'}}}};
+let deleteQueueAction = {type: 'DELETE', meta: {offline: {queue: {method: QueueActionTypes.DELETE, key: '1'}}}};
+let deleteQueueAction2 = {type: 'DELETE2', meta: {offline: {queue: {method: QueueActionTypes.DELETE, key: '2'}}}};
+let readQueueAction = {type: 'READ', meta: {offline: {queue: {method: QueueActionTypes.READ, key: '1'}}}};
+let readQueueAction2 = {type: 'READ2', meta: {offline: {queue: {method: QueueActionTypes.READ, key: '2'}}}};
+
+beforeEach(() => {
+  queue = [];
+});
+// create single item
+test('Single insertion test', () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  expect(queue.length).toBe(1);
+});
+
+// create then update same item
+test(
+  'Create then update same item', () => {
+    queue = Q.enqueue(queue, createQueueAction);
+    queue = Q.enqueue(queue, updateQueueAction);
+    expect(queue.length).toBe(1);
+    expect(Q.peek(queue).type).toBe('UPDATE');
+  }
+);
+
+test(
+  'Create then update then delete same item', () => {
+    queue = Q.enqueue(queue, createQueueAction);
+    queue = Q.enqueue(queue, updateQueueAction);
+    queue = Q.enqueue(queue, deleteQueueAction);
+    expect(queue.length).toBe(0);
+  }
+);
+
+test('Insert then read', () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  expect(Q.peek(queue).meta.offline.queue.key).toBe('1');
+});
+
+test('Insert -> update then read', () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, updateQueueAction);
+  expect(Q.peek(queue).meta.offline.queue.key).toBe('1');
+});
+
+test('Multiple create with same key', () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction);
+  expect(queue.length).toBe(3);
+});
+
+test('Multiple create with different keys', () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction2);
+  queue = Q.enqueue(queue, createQueueAction3);
+  expect(queue.length).toBe(3);
+  expect(Q.peek(queue).type).toBe('CREATE');
+  queue = Q.dequeue(queue);
+  expect(Q.peek(queue).type).toBe('CREATE2');
+  queue = Q.dequeue(queue);
+  expect(Q.peek(queue).type).toBe('CREATE3');
+});
+
+test('Multiple create with same key followed by delete', () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, deleteQueueAction);
+  expect(queue.length).toBe(2);
+});
+
+test('Multiple create with different key followed by delete', () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction2);
+  queue = Q.enqueue(queue, createQueueAction3);
+  queue = Q.enqueue(queue, deleteQueueAction2);
+  expect(queue.length).toBe(2);
+});
+
+test('Multiple create with different key followed by delete and 2 peek', () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction2);
+  queue = Q.enqueue(queue, createQueueAction3);
+  queue = Q.enqueue(queue, deleteQueueAction2);
+  const firstItem = Q.peek(queue);
+  queue = Q.dequeue(queue);
+  const thirdItem = Q.peek(queue);
+  expect(firstItem.type).toBe('CREATE');
+  expect(thirdItem.type).toBe('CREATE3');
+});

--- a/smart-queue/__test__/test.js
+++ b/smart-queue/__test__/test.js
@@ -6,10 +6,15 @@ let createQueueAction = {type: 'CREATE', meta: {offline: {queue: {method: QueueA
 let createQueueAction2 = {type: 'CREATE2', meta: {offline: {queue: {method: QueueActionTypes.CREATE, key: '2'}}}};
 let createQueueAction3 = {type: 'CREATE3', meta: {offline: {queue: {method: QueueActionTypes.CREATE, key: '3'}}}};
 let updateQueueAction = {type: 'UPDATE', meta: {offline: {queue: {method: QueueActionTypes.UPDATE, key: '1'}}}};
+let updateQueueAction2 = {type: 'UPDATE2', meta: {offline: {queue: {method: QueueActionTypes.UPDATE, key: '2'}}}};
+let updateNonExistingQueueAction = {type: 'Non-Existing', meta: {offline: {queue: {method: QueueActionTypes.UPDATE, key: '-1'}}}};
 let deleteQueueAction = {type: 'DELETE', meta: {offline: {queue: {method: QueueActionTypes.DELETE, key: '1'}}}};
 let deleteQueueAction2 = {type: 'DELETE2', meta: {offline: {queue: {method: QueueActionTypes.DELETE, key: '2'}}}};
+let deleteNonExistingQueueAction = {type: 'NON-Existing', meta: {offline: {queue: {method: QueueActionTypes.DELETE, key: '-1'}}}};
 let readQueueAction = {type: 'READ', meta: {offline: {queue: {method: QueueActionTypes.READ, key: '1'}}}};
 let readQueueAction2 = {type: 'READ2', meta: {offline: {queue: {method: QueueActionTypes.READ, key: '2'}}}};
+let missingActionMethod = {type: 'MISSING-METHOD', meta: {offline: {queue: {method: null, key: '2'}}}};
+let missingActionKey = {type: 'MISSING-KEY', meta: {offline: {queue: {method: QueueActionTypes.CREATE, key: null}}}};
 
 beforeEach(() => {
   queue = [];
@@ -48,13 +53,14 @@ test('Insert -> update then read', () => {
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, updateQueueAction);
   expect(Q.peek(queue).meta.offline.queue.key).toBe('1');
+  expect(Q.peek(queue).type).toBe('UPDATE');
 });
 
 test('Multiple create with same key', () => {
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction);
-  expect(queue.length).toBe(3);
+  expect(queue.length).toBe(1);
 });
 
 test('Multiple create with different keys', () => {
@@ -73,8 +79,11 @@ test('Multiple create with same key followed by delete', () => {
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction);
   queue = Q.enqueue(queue, createQueueAction);
+  const item = Q.peek(queue);
+  expect(item.type).toBe('CREATE');
+  expect(queue.length).toBe(1);
   queue = Q.enqueue(queue, deleteQueueAction);
-  expect(queue.length).toBe(2);
+  expect(queue.length).toBe(0);
 });
 
 test('Multiple create with different key followed by delete', () => {
@@ -95,4 +104,82 @@ test('Multiple create with different key followed by delete and 2 peek', () => {
   const thirdItem = Q.peek(queue);
   expect(firstItem.type).toBe('CREATE');
   expect(thirdItem.type).toBe('CREATE3');
+});
+
+test('2 creates followed by update of first item', () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction2);
+  queue = Q.enqueue(queue, updateQueueAction);
+  const firstItem = Q.peek(queue);
+  queue = Q.dequeue(queue);
+  const thirdItem = Q.peek(queue);
+  expect(firstItem.type).toBe('UPDATE');
+  expect(thirdItem.type).toBe('CREATE2');
+});
+
+test('2 creates followed by update of second item', () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction2);
+  queue = Q.enqueue(queue, updateQueueAction2);
+  const firstItem = Q.peek(queue);
+  queue = Q.dequeue(queue);
+  const thirdItem = Q.peek(queue);
+  expect(firstItem.type).toBe('CREATE');
+  expect(thirdItem.type).toBe('UPDATE2');
+});
+
+test('2 reads', () => {
+  queue = Q.enqueue(queue, readQueueAction);
+  queue = Q.enqueue(queue, readQueueAction2);
+  const firstItem = Q.peek(queue);
+  queue = Q.dequeue(queue);
+  const thirdItem = Q.peek(queue);
+  expect(firstItem.type).toBe('READ');
+  expect(thirdItem.type).toBe('READ2');
+});
+
+test('Delete non-existing queue actions', () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction2);
+  queue = Q.enqueue(queue, deleteNonExistingQueueAction);
+  const firstItem = Q.peek(queue);
+  queue = Q.dequeue(queue);
+  const thirdItem = Q.peek(queue);
+  expect(firstItem.type).toBe('CREATE');
+  expect(thirdItem.type).toBe('CREATE2');
+});
+
+test('Update non-existing queue actions', () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction2);
+  queue = Q.enqueue(queue, updateNonExistingQueueAction);
+  const firstItem = Q.peek(queue);
+  queue = Q.dequeue(queue);
+  const thirdItem = Q.peek(queue);
+  expect(firstItem.type).toBe('CREATE');
+  expect(thirdItem.type).toBe('CREATE2');
+});
+
+test('Missing action method', () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction2);
+  queue = Q.enqueue(queue, missingActionMethod);
+  expect(queue.length).toBe(2);
+  const firstItem = Q.peek(queue);
+  queue = Q.dequeue(queue);
+  const thirdItem = Q.peek(queue);
+  expect(firstItem.type).toBe('CREATE');
+  expect(thirdItem.type).toBe('CREATE2');
+});
+
+test('Missing action key', () => {
+  queue = Q.enqueue(queue, createQueueAction);
+  queue = Q.enqueue(queue, createQueueAction2);
+  queue = Q.enqueue(queue, missingActionKey);
+  expect(queue.length).toBe(2);
+  const firstItem = Q.peek(queue);
+  queue = Q.dequeue(queue);
+  const thirdItem = Q.peek(queue);
+  expect(firstItem.type).toBe('CREATE');
+  expect(thirdItem.type).toBe('CREATE2');
 });

--- a/smart-queue/action-types.js
+++ b/smart-queue/action-types.js
@@ -1,0 +1,4 @@
+export const CREATE = 'CREATE';
+export const READ = 'READ';
+export const UPDATE = 'UPDATE';
+export const DELETE = 'DELETE';

--- a/smart-queue/dequeue.js
+++ b/smart-queue/dequeue.js
@@ -1,1 +1,5 @@
 // Don't think is needed but just in case.
+export function dequeue(array, _item) {
+  const [, ...rest] = array;
+  return rest;
+}

--- a/smart-queue/dequeue.js
+++ b/smart-queue/dequeue.js
@@ -1,5 +1,5 @@
 // Don't think is needed but just in case.
-export function dequeue(array, _item) {
+export function dequeue(array, _item, context) {
   const [, ...rest] = array;
   return rest;
 }

--- a/smart-queue/enqueue.js
+++ b/smart-queue/enqueue.js
@@ -1,0 +1,58 @@
+import * as QueueActionTypes from './action-types';
+
+function validKey(key) {
+  if (key === null) {
+    const message = "Every queue action should have a key";
+    console.log(message);
+  }
+  return true;
+}
+
+function indexOfItem(array, key) {
+  return array.findIndex(({meta:{offline:{queue}}}) => queue.key === key);
+}
+
+export function enqueue(array, item) {
+  const { meta: { offline : { queue: { method = 'UNKNOWN', key = null } } } } = item;
+  let index, existingItem;
+
+  if (!validKey(key)) {
+    return array;
+  }
+
+  switch(method) {
+    case QueueActionTypes.CREATE:
+      return [...array, item];
+    case QueueActionTypes.DELETE:
+      index = indexOfItem(array, key);
+      if (index !== -1) {
+        existingItem = array[index];
+        if (existingItem.meta.offline.queue.method === QueueActionTypes.UPDATE ||
+            existingItem.meta.offline.queue.method === QueueActionTypes.CREATE) {
+            array.splice(index, 1);
+        }
+      }
+      return array;
+    case QueueActionTypes.UPDATE:
+      index = indexOfItem(array, key);
+      if (index !== -1) {
+        existingItem = array[index];
+        if (existingItem.meta.offline.queue.method === QueueActionTypes.CREATE) {
+          array[index] = {...array[index], ...item};
+        }
+      }
+      return array;
+    case QueueActionTypes.READ:
+      index = indexOfItem(array, key);
+      if (index !== -1) {
+        existingItem = array[index];
+        if (existingItem.meta.offline.queue.method === QueueActionTypes.READ) {
+          array[index] = {...array[index], ...item};
+        }
+      }
+      return array;
+    default:
+      console.warn('Method not defined in queue action, ignoring this action'); //TODO: improve this message
+      return array
+  }
+}

--- a/smart-queue/enqueue.js
+++ b/smart-queue/enqueue.js
@@ -1,64 +1,78 @@
-import * as QueueActionTypes from './action-types';
+import * as QueueActionTypes from "./action-types";
 
 function validKey(key) {
   if (key === null) {
-    const message = "Missing key, every queue action should have a key!";
-    console.log(message);
+    console.log("Missing key, every queue action should have a key!");
     return false;
   }
   return true;
 }
 
-function indexOfItem(array, key) {
-  return array.findIndex(({meta:{offline:{queue}}}) => queue.key === key);
+function indexOfAction(array, key) {
+  return array.findIndex(
+    ({ meta: { offline: { queue = null } } }) => queue && queue.key === key
+  );
 }
+export function enqueue(array, action) {
+  const { meta: { offline: { queue = null } } } = action;
+  let index, existingAction;
 
-export function enqueue(array, item) {
-  const { meta: { offline : { queue: { method = 'UNKNOWN', key = null } } } } = item;
-  let index, existingItem;
+  if (!queue) {
+    return [...array, action];
+  }
 
+  const { method = "UNKNOWN", key = null } = queue;
   if (!validKey(key)) {
     return array;
   }
 
-  index = indexOfItem(array, key);
+  index = indexOfAction(array, key);
 
-  switch(method) {
+  switch (method) {
     case QueueActionTypes.CREATE:
       if (index !== -1) {
-        array[index] = {...array[index], ...item}; 
+        array[index] = { ...array[index], ...action };
         return array;
       }
-      return [...array, item];
+      return [...array, action];
     case QueueActionTypes.DELETE:
       if (index !== -1) {
-        existingItem = array[index];
-        if (existingItem.meta.offline.queue.method === QueueActionTypes.UPDATE ||
-            existingItem.meta.offline.queue.method === QueueActionTypes.CREATE) {
-            array.splice(index, 1);
+        existingAction = array[index];
+        if (
+          existingAction.meta.offline.queue.method ===
+            QueueActionTypes.UPDATE ||
+          existingAction.meta.offline.queue.method === QueueActionTypes.CREATE
+        ) {
+          array.splice(index, 1);
         }
       }
       return array;
     case QueueActionTypes.UPDATE:
       if (index !== -1) {
-        existingItem = array[index];
-        if (existingItem.meta.offline.queue.method === QueueActionTypes.CREATE) {
-          array[index] = {...array[index], ...item};
+        existingAction = array[index];
+        if (
+          existingAction.meta.offline.queue.method === QueueActionTypes.CREATE
+        ) {
+          array[index] = { ...array[index], ...action };
         }
       }
       return array;
     case QueueActionTypes.READ:
       if (index !== -1) {
-        existingItem = array[index];
-        if (existingItem.meta.offline.queue.method === QueueActionTypes.READ) {
-          array[index] = {...array[index], ...item};
+        existingAction = array[index];
+        if (
+          existingAction.meta.offline.queue.method === QueueActionTypes.READ
+        ) {
+          array[index] = { ...array[index], ...action };
         }
       } else {
-        return [...array, item];
+        return [...array, action];
       }
       return array;
     default:
-      console.log('Missing method definition, the "method" value should be either of [CREATE, READ, DELETE, UPDATE], ignoring this actions!');
-      return array
+      console.log(
+        'Missing method definition, the "method" value should be either of [CREATE, READ, DELETE, UPDATE], ignoring this actions!'
+      );
+      return array;
   }
 }

--- a/smart-queue/enqueue.js
+++ b/smart-queue/enqueue.js
@@ -2,8 +2,9 @@ import * as QueueActionTypes from './action-types';
 
 function validKey(key) {
   if (key === null) {
-    const message = "Every queue action should have a key";
+    const message = "Missing key, every queue action should have a key!";
     console.log(message);
+    return false;
   }
   return true;
 }
@@ -20,11 +21,16 @@ export function enqueue(array, item) {
     return array;
   }
 
+  index = indexOfItem(array, key);
+
   switch(method) {
     case QueueActionTypes.CREATE:
+      if (index !== -1) {
+        array[index] = {...array[index], ...item}; 
+        return array;
+      }
       return [...array, item];
     case QueueActionTypes.DELETE:
-      index = indexOfItem(array, key);
       if (index !== -1) {
         existingItem = array[index];
         if (existingItem.meta.offline.queue.method === QueueActionTypes.UPDATE ||
@@ -34,7 +40,6 @@ export function enqueue(array, item) {
       }
       return array;
     case QueueActionTypes.UPDATE:
-      index = indexOfItem(array, key);
       if (index !== -1) {
         existingItem = array[index];
         if (existingItem.meta.offline.queue.method === QueueActionTypes.CREATE) {
@@ -43,16 +48,17 @@ export function enqueue(array, item) {
       }
       return array;
     case QueueActionTypes.READ:
-      index = indexOfItem(array, key);
       if (index !== -1) {
         existingItem = array[index];
         if (existingItem.meta.offline.queue.method === QueueActionTypes.READ) {
           array[index] = {...array[index], ...item};
         }
+      } else {
+        return [...array, item];
       }
       return array;
     default:
-      console.warn('Method not defined in queue action, ignoring this action'); //TODO: improve this message
+      console.log('Missing method definition, the "method" value should be either of [CREATE, READ, DELETE, UPDATE], ignoring this actions!');
       return array
   }
 }

--- a/smart-queue/index.js
+++ b/smart-queue/index.js
@@ -1,5 +1,5 @@
-import peek from './peek';
-import enqueue from './peek';
-import dequeue from './peek';
+import { peek } from './peek';
+import { enqueue } from './enqueue';
+import { dequeue } from './dequeue';
 
 export default { peek, enqueue, dequeue };

--- a/smart-queue/peek.js
+++ b/smart-queue/peek.js
@@ -1,1 +1,4 @@
 // Don't think is needed but just in case.
+export function peek(array) {
+  return array[0];
+}

--- a/smart-queue/peek.js
+++ b/smart-queue/peek.js
@@ -1,4 +1,4 @@
 // Don't think is needed but just in case.
-export function peek(array) {
+export function peek(array, _item, context) {
   return array[0];
 }


### PR DESCRIPTION
Hi @sorodrigo 
Please have a look at the PR. Let me know if you need any changes.

Please note, as per our communication I have considered that, at any time, there should be only one action with the same key and I have also considered that any `READ` action that does not have any existing action in the `queue` is considered as `enqueue` operation.

Please also note that, if a `CREATE` is enqueued then a `READ` action is enqueued for the same key, then second `READ` operation will be ignored. Please let me know your thought on this.